### PR TITLE
update to build jar compatible with cassandra 2.1.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ cache:
     - $HOME/.m2
 
 install: 
-  - mvn clean install 
+  - mvn clean install -P cassandra20x
+  - mvn install -P cassandra21x
 
 before_deploy:
   - git config --global user.email "builds@travis-ci.com"
@@ -25,6 +26,7 @@ deploy:
   file_glob: true
   file:
     - "./target/cassandra-metrics-reporter-*-cassandra20x.jar"
+    - "./target/cassandra-metrics-reporter-*-cassandra21x.jar"
   on:
     repo: rackerlabs/cassandra-metrics-reporter
     tags: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # cassandra-metrics-reporter
-[ ![Build Status] [travis-image] ] [travis]
-[ ![License] [license-image] ] [license]
 
 # Overview
 
@@ -27,16 +25,19 @@ mvn clean install
 ```
 
 ## For Cassandra 2.1.x
-TBD
+```
+mvn -P cassandra21x install
+```
+
 
 The uber jar should be located in target/ directory
 
 # Version Compatibility Matrix
 
-| Version | Classifier   | Cassandra | Netty | Codahale/DropWizard | metrics-reporter-config | Riemann |
-|---------|--------------|-----------|-------|---------------------|-------------------------|---------|
-| 3.0.3   | cassandra20x | 2.0.x     | 3.x   | 2.x                 | 3.0.3                   | 0.2.8   |
-| 3.0.3   | cassandra21x | 2.1.x     | 4.x   | 2.x                 | 3.0.3                   | 0.2.8   |
+| Version | Classifier   | Cassandra | C* Netty | Codahale/DropWizard | metrics-reporter-config | Riemann |
+|---------|--------------|-----------|----------|---------------------|-------------------------|---------|
+| 3.0.3   | cassandra20x | 2.0.x     | 3.x      | 2.x                 | 3.0.3                   | 0.2.8   |
+| 3.0.3   | cassandra21x | 2.1.x     | 4.x      | 2.x                 | 3.0.3                   | 0.2.8   |
 
 ## Notes
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@ g/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
                         <version>2.2</version>
                         <executions>
                             <execution>
+                                <id>shade-${jar.classifier}</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>shade</goal>
@@ -96,7 +97,77 @@ g/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
                         <version>1.12</version>
                         <executions>
                             <execution>
-                                <id>attach-artifacts</id>
+                                <id>attach-artifacts-${jar.classifier}</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>target/${project.artifactId}-${project.version}-${jar.classifier}.jar</file>
+                                            <type>jar</type>
+                                            <classifier>${jar.classifier}</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- This profile will build the cassandra-metrics-reporter jar 
+                 that's suitable for Cassandra 2.1.x
+            -->
+            <id>cassandra21x</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <jar.classifier>cassandra21x</jar.classifier>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>2.2</version>
+                        <executions>
+                            <execution>
+                                <id>shade-${jar.classifier}</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}-${jar.classifier}</finalName>
+                                    <artifactSet>
+                                        <excludes>
+                                            <!-- We are not excluding Netty dependency of metrics-reporter-config
+                                                 because Cassandra 2.1.x has moved to Netty 4.x. But 
+                                                 metrics-reporter-config's reporter-config2 and Riemann
+                                                 reporter are still using Netty 3.x. The 2 Netty versions
+                                                 happen to have different package names. So essentially,
+                                                 they are "shaded" by default.
+                                            -->
+                                            <exclude>com.yammer.metrics:metrics-core:jar:</exclude>
+                                            <exclude>org.slf4j:slf4j-simple:jar:</exclude>
+                                            <exclude>com.google.guava:guava:jar:</exclude>
+                                        </excludes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.12</version>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts-${jar.classifier}</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>attach-artifact</goal>


### PR DESCRIPTION
This PR updates the build script to build 2 jar files, one for Cassandra 2.0.x, another for Cassandra 2.1.x